### PR TITLE
Remove references to OpenMP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,28 +4,20 @@ file(STRINGS "VERSION" pVersion)
 
 project(nemsiogfs VERSION ${pVersion} LANGUAGES Fortran)
 
-option(OPENMP "use OpenMP threading" OFF)
 option(ENABLE_TESTS "Enable tests" OFF)
 
 if(NOT CMAKE_BUILD_TYPE MATCHES "^(Debug|Release|RelWithDebInfo|MinSizeRel)$")
   message(STATUS "Setting build type to 'Release' as none was specified.")
-  set(CMAKE_BUILD_TYPE
-      "Release"
-      CACHE STRING "Choose the type of build." FORCE)
+  set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build." FORCE)
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
                                                "MinSizeRel" "RelWithDebInfo")
 endif()
 
-if(NOT CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel|GNU|Clang|AppleClang)$")
-  message(
-    WARNING "Compiler not officially supported: ${CMAKE_Fortran_COMPILER_ID}")
+if(NOT CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel|GNU)$")
+  message(WARNING "Compiler not officially supported: ${CMAKE_Fortran_COMPILER_ID}")
 endif()
 
 find_package(nemsio REQUIRED)
-
-if(OPENMP)
-  find_package(OpenMP REQUIRED COMPONENTS Fortran)
-endif()
 
 add_subdirectory(src)
 

--- a/cmake/PackageConfig.cmake.in
+++ b/cmake/PackageConfig.cmake.in
@@ -9,10 +9,6 @@ get_target_property(@PROJECT_NAME@_BUILD_TYPES @PROJECT_NAME@::@PROJECT_NAME@ IM
 
 find_dependency(nemsio CONFIG)
 
-if(@OPENMP@)
-  find_dependency(OpenMP)
-endif()
-
 check_required_components("@PROJECT_NAME@")
 
 get_target_property(location @PROJECT_NAME@::@PROJECT_NAME@ LOCATION)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,10 +14,6 @@ add_library(${lib_name} STATIC ${fortran_src})
 add_library(${PROJECT_NAME}::${lib_name} ALIAS ${lib_name})
 
 set_target_properties(${lib_name} PROPERTIES Fortran_MODULE_DIRECTORY ${module_dir})
-if(OpenMP_Fortran_FOUND)
-  target_link_libraries(${lib_name} PRIVATE OpenMP::OpenMP_Fortran)
-endif()
-set_target_properties(${lib_name} PROPERTIES INTERFACE_LINK_LIBRARIES ${lib_name})
 
 target_include_directories(${lib_name} PUBLIC
   $<BUILD_INTERFACE:${module_dir}>


### PR DESCRIPTION
OpenMP is not used by this library. There is some code in the tests directory that isn't currently built that could use it.
Even so, it doesn't need to be linked to the main library or searched for as a dependency.

Fix comparison of Fortran compiler to Clang

Remove set INTERFACE_LINK_LIBRARIES. There's no need to do that.